### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 ---
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/xmidt-org/eventor/security/code-scanning/5](https://github.com/xmidt-org/eventor/security/code-scanning/5)

In general, this problem is fixed by adding an explicit `permissions:` block to the workflow or to each job that needs it, granting only the minimal scopes necessary. For workflows that just run CI using a reusable workflow and do not themselves perform writes (e.g., no releases or tag pushes from this file), a good conservative default is `contents: read`, which is equivalent to a read‑only default GITHUB_TOKEN for repository contents.

For this specific file, `.github/workflows/ci.yml`, the minimal, non‑breaking change is to add a top‑level `permissions:` block under the existing `name: CI` line. This block will apply to all jobs (including the `ci` job that calls the reusable workflow) unless they define their own permissions. Since we do not see any direct write operations in this workflow definition, we can safely set `contents: read` as the initial least‑privilege setting. If the reusable workflow internally requires broader permissions, it can override them in its own file; if not, this will successfully constrain GITHUB_TOKEN to read‑only for this workflow.

Concretely:
- Edit `.github/workflows/ci.yml` near the top.
- Insert:

  ```yaml
  permissions:
    contents: read
  ```

  between `name: CI` (line 4) and `on:` (line 6).
- No additional imports or definitions are needed since this is pure YAML configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
