### PR TITLE
Normalize CI/CD workflows

### DIFF
--- a/.github/workflows/approve-dependabot.yml
+++ b/.github/workflows/approve-dependabot.yml
@@ -11,6 +11,6 @@ permissions:
   contents:      write
 
 jobs:
-  dependabot:
-    uses: xmidt-org/shared-go/.github/workflows/approve-dependabot.yml@4468342f575e09429c1b04637dcda065145846e4 # v4.9.40
+  package:
+    uses: xmidt-org/.github/.github/workflows/dependabot-approver-template.yml@main
     secrets: inherit

--- a/.github/workflows/approve-dependabot.yml
+++ b/.github/workflows/approve-dependabot.yml
@@ -4,13 +4,14 @@
 name: 'Dependabot auto approval'
 
 on:
-  pull_request_target
+  pull_request_target:
 
 permissions:
   pull-requests: write
-  contents:      write
+  contents: write
 
 jobs:
-  package:
-    uses: xmidt-org/.github/.github/workflows/dependabot-approver-template.yml@main
+  approve:
+    # yamllint disable-line
+    uses: xmidt-org/shared-go/.github/workflows/approve-dependabot.yml@aff0471aa7e2f96ddb059beb178f63747a7cc57e # v4.9.41
     secrets: inherit

--- a/.github/workflows/auto-releaser.yml
+++ b/.github/workflows/auto-releaser.yml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2024 Comcast Cable Communications Management, LLC
 # SPDX-License-Identifier: Apache-2.0
 ---
-name: 'Automatically relase patch versions.'
+name: 'Auto Release'
 
 on:
   schedule: # Run every day at 12:00 UTC
@@ -13,5 +13,6 @@ permissions:
 
 jobs:
   release:
-    uses: xmidt-org/shared-go/.github/workflows/auto-releaser.yml@4468342f575e09429c1b04637dcda065145846e4 # v4.9.40
+    # yamllint disable-line
+    uses: xmidt-org/shared-go/.github/workflows/auto-releaser.yml@aff0471aa7e2f96ddb059beb178f63747a7cc57e # v4.9.41
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Comcast Cable Communications Management, LLC
+# SPDX-FileCopyrightText: 2022 Comcast Cable Communications Management, LLC
 # SPDX-License-Identifier: Apache-2.0
 ---
 name: CI
@@ -19,13 +19,14 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents:      write
   pull-requests: read
-  packages:      write
+  contents: write
+  packages: write
 
 jobs:
   ci:
-    uses: xmidt-org/shared-go/.github/workflows/ci.yml@4468342f575e09429c1b04637dcda065145846e4 # v4.9.40
+    # yamllint disable-line
+    uses: xmidt-org/shared-go/.github/workflows/ci.yml@aff0471aa7e2f96ddb059beb178f63747a7cc57e # v4.9.41
     with:
       release-type:   library
       yaml-lint-skip: false

--- a/.github/workflows/proj-xmidt-team.yml
+++ b/.github/workflows/proj-xmidt-team.yml
@@ -11,12 +11,9 @@ on:
     types:
       - opened
 
-permissions:
-  contents:      read
-  issues:        write
-  pull-requests: write
+permissions: {}
 
 jobs:
-  project:
-    uses: xmidt-org/shared-go/.github/workflows/proj.yml@4468342f575e09429c1b04637dcda065145846e4 # v4.9.40
+  package:
+    uses: xmidt-org/.github/.github/workflows/proj-template.yml@proj-v1
     secrets: inherit

--- a/.github/workflows/proj.yml
+++ b/.github/workflows/proj.yml
@@ -11,9 +11,13 @@ on:
     types:
       - opened
 
-permissions: {}
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
 
 jobs:
-  package:
-    uses: xmidt-org/.github/.github/workflows/proj-template.yml@proj-v1
+  proj:
+    # yamllint disable-line
+    uses: xmidt-org/shared-go/.github/workflows/proj.yml@aff0471aa7e2f96ddb059beb178f63747a7cc57e # v4.9.41
     secrets: inherit


### PR DESCRIPTION
## Summary

This PR normalizes the CI/CD workflows to match the xmidt-org Ideal State standards:

- Renamed `dependabot-approver.yml` to `approve-dependabot.yml`
- Updated workflow references to use `xmidt-org/.github` templates instead of `xmidt-org/shared-go`
- Aligned `proj-xmidt-team.yml` with standard configuration

Resolves #96